### PR TITLE
Pass KeyPath to k0s_rig.SSH

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -359,6 +359,7 @@ func getK0sctlConfig(data *ClusterResourceModel) *k0sctl_v1beta1.Cluster {
 					Address: host.SSH.Address.ValueString(),
 					Port:    int(host.SSH.Port.ValueInt64()),
 					User:    host.SSH.User.ValueString(),
+					KeyPath: host.SSH.KeyPath.ValueString(),
 				},
 			},
 			Role:             host.Role.ValueString(),

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -359,7 +359,7 @@ func getK0sctlConfig(data *ClusterResourceModel) *k0sctl_v1beta1.Cluster {
 					Address: host.SSH.Address.ValueString(),
 					Port:    int(host.SSH.Port.ValueInt64()),
 					User:    host.SSH.User.ValueString(),
-					KeyPath: host.SSH.KeyPath.ValueString(),
+					KeyPath: host.SSH.KeyPath.ValueStringPointer(),
 				},
 			},
 			Role:             host.Role.ValueString(),


### PR DESCRIPTION
Why:

The apparent intent is to allow configuring private key path, but the call to k0s_rig.SSH wasn't passing it.

What:
Pass KeyPath to k0s_rig.SSH in the getK0sctlConfig() function

This fixes #42