### PR TITLE
[DRAFT] raw SSH key, k0sctlconfig, Read phase retries

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -62,6 +62,7 @@ resource "k0s_cluster" "example" {
 ### Read-Only
 
 - `id` (String) Unique ID of the cluster.
+- `k0sctlconfig` (String, Sensitive) k0sctl.yaml of the cluster.
 - `kubeconfig` (String, Sensitive) Admin kubeconfig of the cluster.
 
 <a id="nestedatt--hosts"></a>
@@ -81,6 +82,7 @@ Optional:
 - `os` (String) Override OS distribution auto-detection.
 - `private_address` (String) Override private IP address selected by host fact gathering.
 - `private_interface` (String) Override private network interface selected by host fact gathering. Useful in case fact gathering picks the wrong private network interface.
+- `reset` (Boolean) 'reset' flag.
 
 <a id="nestedatt--hosts--ssh"></a>
 ### Nested Schema for `hosts.ssh`
@@ -93,4 +95,5 @@ Required:
 Optional:
 
 - `key_path` (String) Path to an SSH private key file.
+- `key_raw` (String) PEM encoded SSH private key.
 - `user` (String) Username to log in as.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
-	github.com/hashicorp/terraform-plugin-framework v1.4.0
+	github.com/hashicorp/terraform-plugin-framework v1.4.1
 	github.com/hashicorp/terraform-plugin-go v0.19.0
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/k0sproject/dig v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQH
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-plugin-docs v0.16.0 h1:UmxFr3AScl6Wged84jndJIfFccGyBZn52KtMNsS12dI=
 github.com/hashicorp/terraform-plugin-docs v0.16.0/go.mod h1:M3ZrlKBJAbPMtNOPwHicGi1c+hZUh7/g0ifT/z7TVfA=
-github.com/hashicorp/terraform-plugin-framework v1.4.0 h1:WKbtCRtNrjsh10eA7NZvC/Qyr7zp77j+D21aDO5th9c=
-github.com/hashicorp/terraform-plugin-framework v1.4.0/go.mod h1:XC0hPcQbBvlbxwmjxuV/8sn8SbZRg4XwGMs22f+kqV0=
+github.com/hashicorp/terraform-plugin-framework v1.4.1 h1:ZC29MoB3Nbov6axHdgPbMz7799pT5H8kIrM8YAsaVrs=
+github.com/hashicorp/terraform-plugin-framework v1.4.1/go.mod h1:XC0hPcQbBvlbxwmjxuV/8sn8SbZRg4XwGMs22f+kqV0=
 github.com/hashicorp/terraform-plugin-go v0.19.0 h1:BuZx/6Cp+lkmiG0cOBk6Zps0Cb2tmqQpDM3iAtnhDQU=
 github.com/hashicorp/terraform-plugin-go v0.19.0/go.mod h1:EhRSkEPNoylLQntYsk5KrDHTZJh9HQoumZXbOGOXmec=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=


### PR DESCRIPTION
This is only a draft, but I wanted to let the community know that it's soon to be completed :)

Scope:
- add other option to pass SSH key - as raw PEM-encoded string #94
- add k0sctlconfig as output, so it can be used with k0sctl CLI #76
- handle situation, where k0s leader is not available - attempt to validate cluster on Read phase using all controllers
- investigate ways of actual node removal #95

It can be tested with https://registry.terraform.io/providers/danielskowronski/k0s/